### PR TITLE
Add `--keep-tempfiles` arg

### DIFF
--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -256,6 +256,16 @@ https://pyomicron.readthedocs.io/en/latest/"""
         help='additional file tag to be appended to final '
         'file descriptions',
     )
+
+    outg.add_argument(
+        '-k',
+        '--keep-tempfiles',
+        action='store_true',
+        default=False,
+        help='Keep temporary files after processing.'
+             'Useful for debugging. (default: %(default)s)',
+    )
+
     outg.add_argument('-l', '--log-file', type=Path, help="save a copy of all logger messages to this file")
 
     # data processing/chunking options
@@ -1431,9 +1441,11 @@ def main(args=None):
             f.rename(archive)
         logger.debug("Archived path\n{} --> {}".format(f, archive))
 
-    # clean up temporary files
+
+    # if requested, clean up temporary files
     tempfiles.extend(trigdir.glob("ffconvert.*.ffl"))
-    clean_tempfiles(tempfiles)
+    if not args.keep_tempfiles:
+        clean_tempfiles(tempfiles)
 
     # and exit
     logger.info(f"--- Processing complete. Elapsed: {time.time()-prog_start} seconds ----------------")

--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -265,7 +265,6 @@ https://pyomicron.readthedocs.io/en/latest/"""
         help='Keep temporary files after processing.'
              'Useful for debugging. (default: %(default)s)',
     )
-
     outg.add_argument('-l', '--log-file', type=Path, help="save a copy of all logger messages to this file")
 
     # data processing/chunking options
@@ -1440,7 +1439,6 @@ def main(args=None):
         else:
             f.rename(archive)
         logger.debug("Archived path\n{} --> {}".format(f, archive))
-
 
     # if requested, clean up temporary files
     tempfiles.extend(trigdir.glob("ffconvert.*.ffl"))


### PR DESCRIPTION
Adds `--keep-tempfiles` flag that defaults to `False`. If `True`, will keep temporary files (e.g omicron frame cache files). Useful for the purposes of debugging. 

I have a hunch that the reason the BBHnet generate glitches omicron dags have been failing is due to the [condor dag monitoring](https://github.com/ML4GW/pyomicron/blob/master/omicron/cli/process.py#L1373) exiting early, and thus, files that omicron needs [are being removed](https://github.com/ML4GW/pyomicron/blob/master/omicron/cli/process.py#L1436) before the jobs can get to them. This flag will allow us to get to the bottom of this issue. 