### PR TITLE
Allow verbosity + formats to be passed to omicron

### DIFF
--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -37,6 +37,7 @@ UNUSED_PARAMS = ['state-flag', 'frametype', 'state-channel', 'state-frametype']
 OMICRON_PARAM_MAP = {
     'sample-frequency': ('DATA', 'SAMPLEFREQUENCY'),
     'verbosity': ('OUTPUT', 'VERBOSITY'),
+    'format': ('OUTPUT', 'FORMAT')
 }
 
 

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -35,7 +35,8 @@ from .segments import integer_segments
 CHANNEL_DELIM_REGEX = re.compile(r'[:_-]')
 UNUSED_PARAMS = ['state-flag', 'frametype', 'state-channel', 'state-frametype']
 OMICRON_PARAM_MAP = {
-    'sample-frequency': ('DATA', 'SAMPLEFREQUENCY')
+    'sample-frequency': ('DATA', 'SAMPLEFREQUENCY'),
+    'verbosity': ('OUTPUT', 'VERBOSITY'),
 }
 
 


### PR DESCRIPTION
Allows user to specify omicrons verbosity setting (integer between 0-3) in `.ini`.
Allow user to specify trigger output formats. (e.g. _only_ `hdf5`)